### PR TITLE
Update Ward et al. citation

### DIFF
--- a/data/citations/epichains.bib
+++ b/data/citations/epichains.bib
@@ -10,13 +10,18 @@
 	date = {2025-02-21},
 }
 
-@article{Ward2024.12.11.24318702,
-	author = {Ward, Jack and Lambert, Joshua W. and Russell, Timothy W. and Azam, James M. and Kucharski, Adam J. and Funk, Sebastian and Quilty, Billy J. and Gressani, Oswaldo and Hens, Niel and Edmunds, W. John},
-	title = {Estimates of epidemiological parameters for H5N1 influenza in humans: a rapid review},
-	year = {2024},
-	doi = {10.1101/2024.12.11.24318702},
-	publisher = {Cold Spring Harbor Laboratory Press},
-	journal = {medRxiv}
+@article{Ward2025,
+  title = {Estimates of epidemiological parameters for H5N1 influenza in humans: a rapid review},
+  volume = {25},
+  ISSN = {1471-2334},
+  url = {http://dx.doi.org/10.1186/s12879-025-11933-z},
+  DOI = {10.1186/s12879-025-11933-z},
+  number = {1},
+  journal = {BMC Infectious Diseases},
+  publisher = {Springer Science and Business Media LLC},
+  author = {Ward,  Jack and Lambert,  Joshua W. and Russell,  Timothy W. and Azam,  James M. and Kucharski,  Adam J. and Funk,  Sebastian and Quilty,  Billy J. and Gressani,  Oswaldo and Hens,  Niel and Edmunds,  W. John},
+  year = {2025},
+  month = dec 
 }
 
 @article{bidari2025assessing,


### PR DESCRIPTION
This PR updates the Ward et al. (2025) citation that mentions {epichains} from the pre-print on medRxiv to the published paper in BMC Infectious Diseases.