### PR TITLE
Add Morariu et al. (2025) citation to epichains and epidemics

### DIFF
--- a/data/citations/epichains.bib
+++ b/data/citations/epichains.bib
@@ -21,7 +21,7 @@
   publisher = {Springer Science and Business Media LLC},
   author = {Ward,  Jack and Lambert,  Joshua W. and Russell,  Timothy W. and Azam,  James M. and Kucharski,  Adam J. and Funk,  Sebastian and Quilty,  Billy J. and Gressani,  Oswaldo and Hens,  Niel and Edmunds,  W. John},
   year = {2025},
-  month = dec 
+  month = dec
 }
 
 @article{bidari2025assessing,
@@ -44,4 +44,13 @@
   author = {Ward, Jack and Gressani, Oswaldo and Kim, Sol and Hens, Niel and Edmunds, W. John},
   year = {2026},
   pages = {100882}
+}
+
+@article{morariu2025gemlib,
+  title = {{gemlib}: Probabilistic programming for epidemic models},
+  author = {Morariu, Alin and Bridgen, Jess and Jewell, Chris},
+  year = {2025},
+  doi = {10.48550/arXiv.2511.08124},
+  url = {https://arxiv.org/abs/2511.08124},
+  journal = {arXiv preprint}
 }

--- a/data/citations/epidemics.bib
+++ b/data/citations/epidemics.bib
@@ -10,11 +10,11 @@
 	year = {2024}
 }
 
-@misc{morariu2025gemlib,
+@article{morariu2025gemlib,
   title = {{gemlib}: Probabilistic programming for epidemic models},
   author = {Morariu, Alin and Bridgen, Jess and Jewell, Chris},
   year = {2025},
   doi = {10.48550/arXiv.2511.08124},
   url = {https://arxiv.org/abs/2511.08124},
-  publisher = {arXiv}
+  journal = {arXiv preprint}
 }

--- a/data/citations/epidemics.bib
+++ b/data/citations/epidemics.bib
@@ -9,3 +9,12 @@
 	month = feb,
 	year = {2024}
 }
+
+@misc{morariu2025gemlib,
+  title = {{gemlib}: Probabilistic programming for epidemic models},
+  author = {Morariu, Alin and Bridgen, Jess and Jewell, Chris},
+  year = {2025},
+  doi = {10.48550/arXiv.2511.08124},
+  url = {https://arxiv.org/abs/2511.08124},
+  publisher = {arXiv}
+}


### PR DESCRIPTION
## Summary

- Add Morariu, Bridgen & Jewell "gemlib: Probabilistic programming for epidemic models" (arXiv:2511.08124, 2025) as a citation of both **epichains** and **epidemics**
- DOI: [10.48550/arXiv.2511.08124](https://doi.org/10.48550/arXiv.2511.08124)
- arXiv: https://arxiv.org/abs/2511.08124

Closes #29

## Test plan

- [x] DOI/arXiv link resolves correctly
- [ ] Site builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)